### PR TITLE
added version values to allow for use of nbgv prepare-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For client-side and server-side Blazor - add script section to index.html or _Ho
 
 ```xml
     <link href="_content/Chartist.Blazor/chartist.min.css" rel="stylesheet" />
-    <script src="_content/Chartist.Blazor/chartist.min.js"></script>
+    <script src="_content/Chartist.Blazor/chartist.js"></script>
     <script src="_content/Chartist.Blazor/blazorChartistInterop.js"></script>
 ```
 

--- a/version.json
+++ b/version.json
@@ -1,13 +1,18 @@
 {
-  "version": "1.0",
-    "assemblyVersion": {
-      "precision": "revision"
-    },
-    "publicReleaseRefSpec": [
-      "^refs/heads/master$",
-      "^refs/heads/rel/v\\d+\\.\\d+"
-    ],
-    "nugetPackageVersion": {
-      "semVer": 2
-    }
+  "version": "1.0-prerelease",
+  "assemblyVersion": {
+    "precision": "revision"
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/rel/v\\d+\\.\\d+"
+  ],
+  "nugetPackageVersion": {
+    "semVer": 2
+  },
+  "release": {
+    "branchName": "rel/v{version}",
+    "versionIncrement": "minor",
+    "firstUnstableTag": "prerelease"
   }
+}


### PR DESCRIPTION
reset version to pre-rel and added section to version.json to allow or nbgv prepare-release.

corrected readme - installation to add chartist.js instead of chartist.min.js